### PR TITLE
Update footer as 'code of conduct' link in menu

### DIFF
--- a/templates/footer.pebble
+++ b/templates/footer.pebble
@@ -4,8 +4,6 @@
                 Made by and for the Manchester Java Community members
                 <br>
                 <a class="has-text-link-dark" href="mailto:organisers@manchesterjavacommunity.org">organisers@manchesterjavacommunity.org</a>
-                <br>
-                <a class="has-text-link-dark" href="/code-of-conduct.html">Code of Conduct</a>
             </p>
         </div>
     </footer>


### PR DESCRIPTION
'Code of conduct' link now has a place in the menu, no need to clutter up the footer.